### PR TITLE
Add typed astrometry backend configs and validate them

### DIFF
--- a/skylib/astrometry/astap_solver.py
+++ b/skylib/astrometry/astap_solver.py
@@ -13,13 +13,12 @@ import os
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Optional
 
-import numpy as np
 from astropy.io import fits
 from astropy.wcs import WCS
 
-from .main import Solution
+from .solution import Solution
 
 __all__ = ["solve_astap"]
 

--- a/skylib/astrometry/backends/__init__.py
+++ b/skylib/astrometry/backends/__init__.py
@@ -1,0 +1,30 @@
+"""Astrometry backend registry."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .astap import AstapBackend
+from .astrometry_net import AstrometryNetBackend
+from .platesolve import PlateSolveBackend
+
+__all__ = ["available_backends", "get_backend"]
+
+
+_BACKENDS: Dict[str, object] = {
+    "an": AstrometryNetBackend(),
+    "astrometry_net": AstrometryNetBackend(),
+    "astap": AstapBackend(),
+    "platesolve": PlateSolveBackend(),
+}
+
+
+def get_backend(name: str):
+    try:
+        return _BACKENDS[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown backend '{name}'") from exc
+
+
+def available_backends() -> list[str]:
+    return [name for name, backend in _BACKENDS.items() if backend.is_available()]

--- a/skylib/astrometry/backends/astap.py
+++ b/skylib/astrometry/backends/astap.py
@@ -1,0 +1,45 @@
+"""ASTAP backend implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..astap_solver import solve_astap
+from ..configs import AstapConfig
+from ..request import SolveRequest
+from ..solution import Solution
+
+__all__ = ["AstapBackend"]
+
+
+class AstapBackend:
+    name = "astap"
+
+    def is_available(self) -> bool:
+        return True
+
+    def solve(self, request: SolveRequest, engine=None) -> Solution:
+        if request.image_path is None:
+            raise ValueError("image_path must be provided for ASTAP backend")
+
+        if request.backend_config is None:
+            config = AstapConfig()
+        elif isinstance(request.backend_config, AstapConfig):
+            config = request.backend_config
+        else:
+            raise TypeError("ASTAP backend requires AstapConfig configuration")
+
+        return solve_astap(
+            image_path=Path(request.image_path),
+            ra_hours=request.ra_hours,
+            dec_degs=request.dec_degs,
+            radius=request.radius,
+            fov=request.fov,
+            cmd=config.cmd,
+            catalog=config.catalog,
+            downsample=(
+                config.downsample
+                if config.downsample is not None
+                else request.downsample
+            ),
+        )

--- a/skylib/astrometry/backends/astrometry_net.py
+++ b/skylib/astrometry/backends/astrometry_net.py
@@ -1,0 +1,314 @@
+"""Astrometry.net backend implementation."""
+
+from __future__ import annotations
+
+import ctypes
+import importlib
+import os
+import sys
+from glob import glob
+
+import numpy
+from astropy.wcs import Sip, WCS
+
+from ..request import SolveRequest
+from ..solution import Solution
+
+_an_engine_spec = importlib.util.find_spec("skylib.astrometry.an_engine")
+if _an_engine_spec is None:  # pragma: no cover - optional dependency
+    an_engine = None
+else:  # pragma: no cover - optional dependency
+    an_engine = importlib.import_module("skylib.astrometry.an_engine")
+
+__all__ = ["AstrometryNetBackend", "Solver"]
+
+
+class Solver(object):
+    """
+    Class that encapsulates the :class:`skylib.astrometry.an_engine.solver_t`
+    object and the list of indexes. An instance is created in each solver
+    thread and is supplied to the astrometry.net backend.
+
+    Attributes::
+        solver: Astrometry.net engine :class:`an_engine.solver_t` object
+        indexes: list of :class:`an_engine.index_t` instances
+        globs: (RA_hours, Dec_degs, r_arcmins) list of globular clusters
+            utilized by :func:`solve_field_glob` to find a WCS solution
+            in the vicinity of a globular cluster
+    """
+
+    globs = None  # type: list
+
+    def __init__(self, index_path):
+        """
+        Create solver
+
+        :param str | list index_path: directory or list of directories
+            containing index files
+        """
+        if an_engine is None:
+            raise ImportError("an_engine module not available")
+
+        if isinstance(index_path, str):
+            index_path = [index_path]
+
+        self.solver = an_engine.solver_new()
+
+        self.indexes = []
+        for path in index_path:
+            for fn in glob(os.path.join(path, "*")):
+                # noinspection PyBroadException
+                try:
+                    idx = an_engine.index_load(fn, 0, None)
+                    if idx is not None:
+                        self.indexes.append(idx)
+                except Exception:
+                    pass
+
+        if not self.indexes:
+            raise ValueError("No indexes found")
+
+        # Sort indexes by the number of quads (try smaller indexes first -
+        # should be faster)
+        self.indexes.sort(key=lambda _idx: _idx.nquads)
+
+        # Load the list of globular clusters
+        self.globs = []
+        with open(os.path.join(os.path.dirname(__file__), "..", "ngc2000.dat")) as f:
+            for line in f.read().splitlines():
+                # noinspection PyBroadException
+                try:
+                    typ = line[6:9].strip()
+                    if typ != "Gb":
+                        continue
+                    ra_h, ra_m = line[10:12], line[13:17]
+                    dec_s, dec_d, dec_m = line[19], line[20:22], line[23:25]
+                    ra = (int(ra_h) + float(ra_m) / 60)
+                    dec = (1 - 2 * (dec_s == "-")) * (
+                        int(dec_d) + int(dec_m) / 60.0
+                    )
+                    r = float(line[33:38]) / 2
+                    self.globs.append([ra, dec, r / 60])
+                except Exception:
+                    pass
+
+
+def _array_from_swig(data, shape, dtype=numpy.float64):
+    a = numpy.empty(shape, dtype)
+    ctypes.memmove(a.ctypes, int(data), a.nbytes)
+    return a
+
+
+class AstrometryNetBackend:
+    name = "an"
+
+    def is_available(self) -> bool:
+        return an_engine is not None
+
+    def solve(self, request: SolveRequest, engine=None) -> Solution:
+        if an_engine is None:
+            raise ImportError("an_engine module not available")
+
+        if request.xy is None:
+            raise ValueError("xy must be provided for Astrometry.net backend")
+
+        if engine is None:
+            raise ValueError("engine must be provided for Astrometry.net backend")
+
+        solver = engine.solver
+        ra = float(request.ra_hours) * 15
+        dec = float(request.dec_degs)
+        r = float(request.radius)
+
+        # Set timer callback if requested
+        if request.callback is not None:
+            if sys.platform.startswith("win32"):
+                time_t = ctypes.c_int64
+            elif ctypes.sizeof(ctypes.c_void_p) == ctypes.sizeof(ctypes.c_int64):
+                time_t = ctypes.c_int64
+            else:
+                time_t = ctypes.c_int32
+            an_engine.set_timer_callback(
+                solver,
+                ctypes.cast(ctypes.CFUNCTYPE(time_t)(request.callback), ctypes.c_voidp)
+                .value,
+            )
+        else:
+            an_engine.set_timer_callback(solver, 0)
+
+        # Set field star position array
+        xy = numpy.asanyarray(request.xy)
+        n = len(xy)
+        flux = request.flux
+        field = an_engine.starxy_new(n, flux is not None, False)
+        if flux is not None:
+            flux = numpy.asanyarray(flux)
+            if len(flux) != n:
+                raise ValueError("Flux array must be of the same length as XY array")
+            if request.max_sources:
+                order = numpy.argsort(flux)[::-1]
+                xy, flux = xy[order], flux[order]
+                del order
+            an_engine.starxy_set_flux_array(field, flux)
+        an_engine.starxy_set_xy_array(field, xy.ravel())
+        an_engine.solver_set_field(solver, field)
+
+        try:
+            # Initialize solver parameters
+            if request.width:
+                minx, maxx = 1, int(request.width)
+            else:
+                minx, maxx = xy[:, 0].min(), xy[:, 0].max()
+            if request.height:
+                miny, maxy = 1, int(request.height)
+            else:
+                miny, maxy = xy[:, 1].min(), xy[:, 1].max()
+            an_engine.solver_set_field_bounds(solver, minx, maxx, miny, maxy)
+            solver.quadsize_min = 0.1 * min(maxx - minx + 1, maxy - miny + 1)
+
+            if request.crpix_center != "":
+                solver.set_crpix = solver.set_crpix_center = int(request.crpix_center)
+
+            an_engine.solver_set_radec(solver, ra, dec, r)
+
+            solver.funits_lower = float(request.min_scale)
+            solver.funits_upper = float(request.max_scale)
+
+            solver.logratio_tokeep = numpy.log(1e12)
+            solver.distance_from_quad_bonus = True
+
+            if request.parity is None or request.parity == "":
+                solver.parity = an_engine.PARITY_BOTH
+            elif int(request.parity):
+                solver.parity = an_engine.PARITY_NORMAL
+            else:
+                solver.parity = an_engine.PARITY_FLIP
+
+            enable_sip = request.sip_order and int(request.sip_order) >= 2
+            if enable_sip:
+                solver.do_tweak = True
+                solver.tweak_aborder = int(request.sip_order)
+                solver.tweak_abporder = int(request.sip_order) + 1
+            else:
+                solver.do_tweak = False
+
+            if request.max_sources:
+                solver.endobj = request.max_sources
+            else:
+                solver.endobj = 0
+
+            # Find indexes needed to solve the field
+            fmin = solver.quadsize_min * request.min_scale
+            fmax = numpy.hypot(request.width, request.height) * request.max_scale
+            indices = []
+            for index in engine.indexes:
+                if fmin > index.index_scale_upper or fmax < index.index_scale_lower:
+                    continue
+                if not an_engine.index_is_within_range(index, ra, dec, r):
+                    continue
+
+                indices.append(index)
+
+            if not len(indices):
+                raise ValueError("No indexes found for the given scale and position")
+
+            # Sort indices by scale (larger scales/smaller indices first - should
+            # be faster) then by distance from expected position
+            indices.sort(
+                key=lambda _idx: (
+                    -_idx.index_scale_upper,
+                    an_engine.healpix_distance_to_radec(
+                        _idx.healpix, _idx.hpnside, ra, dec
+                    )[0]
+                    if _idx.healpix >= 0
+                    else 0,
+                )
+            )
+            an_engine.solver_clear_indexes(solver)
+            for index in indices:
+                an_engine.solver_add_index(solver, index)
+
+            # Run the solver
+            an_engine.solver_run(solver)
+            sol = Solution()
+            sol.backend = self.name
+
+            if solver.have_best_match:
+                best_match = solver.best_match
+                sol.log_odds = solver.best_logodds
+                sol.n_match = best_match.nmatch
+                sol.n_conflict = best_match.nconflict
+                sol.n_field = best_match.nfield
+                if best_match.index is not None:
+                    sol.index_name = best_match.index.indexname
+            else:
+                best_match = None
+
+            if solver.best_match_solves:
+                # Get WCS parameters of best solution
+                sol.wcs = WCS(naxis=2)
+
+                wcs_ctype = ("RA---TAN", "DEC--TAN")
+                if enable_sip:
+                    sip = best_match.sip
+                    try:
+                        wcstan = sip.wcstan
+                    except AttributeError:
+                        # Unable to compute SIP distortions, too few sources?
+                        wcstan = best_match.wcstan
+                    else:
+                        a_order, b_order = sip.a_order, sip.b_order
+                        if a_order > 0 or b_order > 0:
+                            ap_order, bp_order = sip.ap_order, sip.bp_order
+                            maxorder = an_engine.SIP_MAXORDER
+                            a = _array_from_swig(
+                                sip.a, (maxorder, maxorder)
+                            )[: a_order + 1, : a_order + 1]
+                            b = _array_from_swig(
+                                sip.b, (maxorder, maxorder)
+                            )[: b_order + 1, : b_order + 1]
+                            if a.any() or b.any():
+                                ap = _array_from_swig(
+                                    sip.ap, (maxorder, maxorder)
+                                )[: ap_order + 1, : ap_order + 1]
+                                bp = _array_from_swig(
+                                    sip.bp, (maxorder, maxorder)
+                                )[: bp_order + 1, : bp_order + 1]
+                                sol.wcs.sip = Sip(
+                                    a, b, ap, bp, _array_from_swig(wcstan.crpix, (2,))
+                                )
+                                wcs_ctype = ("RA---TAN-SIP", "DEC--TAN-SIP")
+                else:
+                    wcstan = best_match.wcstan
+                sol.wcs.wcs.ctype = wcs_ctype
+                sol.wcs.wcs.crpix = _array_from_swig(wcstan.crpix, (2,))
+                sol.wcs.wcs.crval = _array_from_swig(wcstan.crval, (2,))
+                sol.wcs.wcs.cd = _array_from_swig(wcstan.cd, (2, 2))
+            elif request.retry_lost and (request.radius < 180 or request.parity is not None):
+                # When no solution was found, retry with all constraints relaxed
+                an_engine.solver_cleanup_field(solver)
+                relaxed_request = SolveRequest(
+                    xy=request.xy,
+                    flux=request.flux,
+                    width=request.width,
+                    height=request.height,
+                    ra_hours=0,
+                    dec_degs=0,
+                    radius=180,
+                    min_scale=request.min_scale,
+                    max_scale=request.max_scale,
+                    parity=None,
+                    sip_order=request.sip_order,
+                    crpix_center=request.crpix_center,
+                    max_sources=request.max_sources,
+                    retry_lost=False,
+                    callback=request.callback,
+                    backend_config=request.backend_config,
+                )
+                return self.solve(relaxed_request, engine=engine)
+
+            return sol
+        finally:
+            # Cleanup and make solver ready for the next solution
+            an_engine.solver_cleanup_field(solver)
+            an_engine.solver_clear_indexes(solver)

--- a/skylib/astrometry/backends/base.py
+++ b/skylib/astrometry/backends/base.py
@@ -1,0 +1,22 @@
+"""Backend interface for astrometric solvers."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from ..request import SolveRequest
+from ..solution import Solution
+
+__all__ = ["SolverBackend"]
+
+
+class SolverBackend(Protocol):
+    """Interface for backend implementations."""
+
+    name: str
+
+    def is_available(self) -> bool:
+        """Return True if the backend can run in this environment."""
+
+    def solve(self, request: SolveRequest, engine=None) -> Solution:
+        """Solve an astrometric request."""

--- a/skylib/astrometry/backends/platesolve.py
+++ b/skylib/astrometry/backends/platesolve.py
@@ -1,0 +1,85 @@
+"""PlateSolve 3.8 backend implementation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from astropy.io import fits
+from astropy.wcs import WCS
+
+from ..configs import PlateSolveConfig
+from ..request import SolveRequest
+from ..solution import Solution
+
+__all__ = ["PlateSolveBackend"]
+
+
+class PlateSolveBackend:
+    name = "platesolve"
+
+    def is_available(self) -> bool:
+        return True
+
+    def _build_cmdline(self, request: SolveRequest) -> list[str]:
+        if request.backend_config is None:
+            config = PlateSolveConfig()
+        elif isinstance(request.backend_config, PlateSolveConfig):
+            config = request.backend_config
+        else:
+            raise TypeError("PlateSolve backend requires PlateSolveConfig configuration")
+
+        cmdline = config.cmdline
+        if cmdline:
+            return [str(part).format(
+                image_path=request.image_path,
+                ra_hours=request.ra_hours,
+                dec_degs=request.dec_degs,
+                fov=request.fov,
+                radius=request.radius,
+            ) for part in cmdline]
+
+        cmd = config.cmd
+        if not cmd:
+            raise ValueError(
+                "PlateSolve backend requires PlateSolveConfig.cmd or "
+                "PlateSolveConfig.cmdline"
+            )
+
+        if request.image_path is None:
+            raise ValueError("image_path must be provided for PlateSolve backend")
+
+        return [cmd, str(request.image_path)]
+
+    def solve(self, request: SolveRequest, engine=None) -> Solution:
+        if request.image_path is None:
+            raise ValueError("image_path must be provided for PlateSolve backend")
+
+        cmdline = self._build_cmdline(request)
+        subprocess.run(cmdline, check=False)
+
+        if request.backend_config is None:
+            config = PlateSolveConfig()
+        elif isinstance(request.backend_config, PlateSolveConfig):
+            config = request.backend_config
+        else:
+            raise TypeError("PlateSolve backend requires PlateSolveConfig configuration")
+
+        wcs_path = config.wcs_path
+        if wcs_path is None:
+            wcs_path = Path(request.image_path).with_suffix(".wcs")
+        else:
+            wcs_path = Path(wcs_path)
+
+        sol = Solution()
+        sol.backend = self.name
+        sol.backend_metadata = {"cmdline": cmdline}
+
+        if os.path.exists(wcs_path):
+            try:
+                hdr = fits.Header.fromtextfile(str(wcs_path))
+                sol.wcs = WCS(hdr)
+            except Exception:
+                sol.wcs = None
+        return sol

--- a/skylib/astrometry/configs.py
+++ b/skylib/astrometry/configs.py
@@ -1,0 +1,31 @@
+"""Backend configuration dataclasses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+__all__ = [
+    "BackendConfig",
+    "AstapConfig",
+    "PlateSolveConfig",
+]
+
+
+class BackendConfig:
+    """Marker base class for backend configurations."""
+
+
+@dataclass
+class AstapConfig(BackendConfig):
+    cmd: str = "astap_cli"
+    catalog: str | None = "C:/astap"
+    downsample: int | None = None
+
+
+@dataclass
+class PlateSolveConfig(BackendConfig):
+    cmd: str | None = None
+    cmdline: Sequence[str] | None = None
+    wcs_path: Path | None = None

--- a/skylib/astrometry/main.py
+++ b/skylib/astrometry/main.py
@@ -1,462 +1,73 @@
-"""SkyLib astrometric reduction package
+"""SkyLib astrometric reduction package.
 
-This module primarily interfaces with the local Astrometry.net engine binding
-but can fall back to the `ASTAP <https://www.hnsky.org/astap.htm>`_ solver if
-the binding is unavailable or if the user explicitly selects it via
-``solve_field(..., backend="astap")``.  The ASTAP executable and its star
-catalog must be installed separately; the code only points ASTAP to an existing
-catalog.
+This module provides a backend-agnostic interface to multiple astrometric
+solvers, including Astrometry.net, ASTAP, and PlateSolve 3.8.
 """
 
 from __future__ import absolute_import, division, print_function
 
-import os
-import sys
-from glob import glob
-import ctypes
-from pathlib import Path
 from typing import Optional
 
 import numpy
-from astropy.wcs import Sip, WCS
 
-from skylib.util.angle import angdist
+from .backends import available_backends, get_backend
+from .backends.astrometry_net import Solver
+from .request import SolveRequest
+from .solution import Solution
+from ..util.angle import angdist
 
-try:  # pragma: no cover - optional dependency
-    from . import an_engine
-except Exception:  # pragma: no cover - missing optional dependency
-    an_engine = None
-
-
-__all__ = ['Solver', 'solve_field', 'solve_field_glob']
+__all__ = ["Solver", "SolveRequest", "Solution", "solve_field", "solve_field_glob"]
 
 
-class Solver(object):
-    """
-    Class that encapsulates the :class:`skylib.astrometry.an_engine.solver_t`
-    object and the list of indexes. An instance is created in each solver
-    thread and is supplied to :func:`solve_field`.
-
-    Attributes::
-        solver: Astrometry.net engine :class:`an_engine.solver_t` object
-        indexes: list of :class:`an_engine.index_t` instances
-        globs: (RA_hours, Dec_degs, r_arcmins) list of globular clusters
-            utilized by :func:`solve_field_glob` to find a WCS solution
-            in the vicinity of a globular cluster
-    """
-    globs = None  # type: list
-
-    def __init__(self, index_path):
-        """
-        Create solver
-
-        :param str | list index_path: directory or list of directories
-            containing index files
-        """
-        if an_engine is None:
-            raise ImportError('an_engine module not available')
-
-        if isinstance(index_path, str):
-            index_path = [index_path]
-
-        self.solver = an_engine.solver_new()
-
-        self.indexes = []
-        for path in index_path:
-            for fn in glob(os.path.join(path, '*')):
-                # noinspection PyBroadException
-                try:
-                    idx = an_engine.index_load(fn, 0, None)
-                    if idx is not None:
-                        self.indexes.append(idx)
-                except Exception:
-                    pass
-
-        if not self.indexes:
-            raise ValueError('No indexes found')
-
-        # Sort indexes by the number of quads (try smaller indexes first -
-        # should be faster)
-        self.indexes.sort(key=lambda _idx: _idx.nquads)
-
-        # Load the list of globular clusters
-        self.globs = []
-        with open(os.path.join(os.path.dirname(__file__), 'ngc2000.dat')) as f:
-            for line in f.read().splitlines():
-                # noinspection PyBroadException
-                try:
-                    typ = line[6:9].strip()
-                    if typ != 'Gb':
-                        continue
-                    ra_h, ra_m = line[10:12], line[13:17]
-                    dec_s, dec_d, dec_m = line[19], line[20:22], line[23:25]
-                    ra = (int(ra_h) + float(ra_m)/60)
-                    dec = (1 - 2*(dec_s == '-'))*(int(dec_d) + int(dec_m)/60.0)
-                    r = float(line[33:38])/2
-                    self.globs.append([ra, dec, r/60])
-                except Exception:
-                    pass
+def _select_default_backend() -> str:
+    preferred = ["an", "astap", "platesolve"]
+    available = set(available_backends())
+    for name in preferred:
+        if name in available:
+            return name
+    raise RuntimeError("No astrometry backends are available")
 
 
-class Solution(object):
-    """
-    Class that encapsulates the results of astrometric reduction, including WCS
-    and some solution statistics
-
-    Attributes::
-        wcs: :class:`astropy.wcs.WCS` containing the World Coordinate System
-            info for solution; None if solution was not found
-        log_odds: logodds of best match
-        n_match: number of matched sources
-        n_conflict: number of conflicts
-        n_field: total number of sources
-        index_name: index file name that solved the image
-    """
-    wcs: WCS | None = None  # type: WCS
-    log_odds: float | None = None
-    n_match: int | None = None
-    n_conflict: int | None = None
-    n_field: int | None = None
-    index_name: str | None = None
-
-
-def array_from_swig(data, shape, dtype=numpy.float64):
-    a = numpy.empty(shape, dtype)
-    ctypes.memmove(a.ctypes, int(data), a.nbytes)
-    return a
-
-
-def solve_field(engine=None, xy=None, flux=None, width=None, height=None,
-                ra_hours=0, dec_degs=0, radius=180, min_scale=0.1,
-                max_scale=10, fov=None, parity=None, sip_order=3,
-                crpix_center=True, max_sources=None, retry_lost=True,
-                callback=None, backend=None, astap_cmd='astap_cli',
-                astap_catalog= "C:/astap", image_path: Path=None, downsample: Optional[int] = None) -> Solution:
-    """
-    Obtain astrometric solution given XY coordinates of field stars
-
-    :param :class:`Solver` engine: Astrometry.net engine solver instance;
-        optional when using the ASTAP backend
-    :param array_like xy: (n x 2) array of 1-based X and Y pixel coordinates
-        of stars
-    :param array_like flux: optional n-element array of star fluxes
-    :param int width: image width in pixels; defaults to the maximum minus
-        minimum X coordinate of stars
-    :param int height: image height in pixels; defaults to the maximum minus
-        minimum Y coordinate of stars
-    :param float ra_hours: optional RA of image center in hours; default: 0
-    :param float dec_degs: optional Dec of image center in degrees; default: 0
-    :param float radius: optional field search radius in degrees; default: 180
-        (search over the whole sky)
-    :param float min_scale: optional minimum pixel scale in arcseconds per
-        pixel; default: 0.1
-    :param float max_scale: optional maximum pixel scale in arcseconds per
-        pixel; default: 10
-    :param float fov: field of view in degrees for the ASTAP backend;
-        ignored for the Astrometry.net backend
-    :param bool | None parity: image parity (sign of coordinate transformation
-        matrix determinant): True = normal parity, False = flipped image, None
-        (default) = try both
-    :param int sip_order: order of SIP distortion terms; default: 3;
-        0 - disable calculation of distortion
-    :param bool crpix_center: set reference pixel to image center
-    :param int max_sources: use only the given number of brightest sources;
-        0/""/None (default) = no limit
-    :param bool retry_lost: if solution failed, retry in the "lost in space"
-        mode, i.e. without coordinate restrictions (`radius` = 180) and with
-        opposite parity, unless the initial search already had these
-        restrictions disabled
-    :param callable callback: optional callable that is regularly called
-        by the solver, accepts no arguments, and returns 0 to interrupt
-        the solution and 1 otherwise
-    :param str backend: ``"an"`` for Astrometry.net (default if available) or
-        ``"astap"`` to use the ASTAP solver
-    :param str astap_cmd: path to ASTAP executable when using the ASTAP backend
-    :param str astap_catalog: path to the ASTAP star catalog directory
-
-    :return: astrometric solution object; its `wcs` attribute is set to None if
-        solution was not found
-    """
-
-    if xy is None:
-        raise ValueError('xy must be provided')
+def solve_field(
+    request: SolveRequest,
+    backend: Optional[str] = None,
+    engine=None,
+) -> Solution:
+    """Solve a field using the selected backend."""
 
     if backend is None:
-        backend = 'an' if an_engine is not None else 'astap'
+        backend = _select_default_backend()
 
-    if backend == 'astap':
-        from . import astap_solver
-        if image_path is None:
-            raise ValueError('image_path must be provided for ASTAP backend')
-        
-     
-        return astap_solver.solve_astap(image_path=image_path, ra_hours=ra_hours,
-            dec_degs=dec_degs, radius=radius, fov=fov, cmd=astap_cmd,
-            catalog=astap_catalog, downsample=downsample)
-
-    if engine is None:
-        raise ValueError('engine must be provided for Astrometry.net backend')
-    solver = engine.solver
-    ra = float(ra_hours)*15
-    dec = float(dec_degs)
-    r = float(radius)
-
-    # Set timer callback if requested
-    if callback is not None:
-        if sys.platform.startswith('win32'):
-            time_t = ctypes.c_int64
-        elif ctypes.sizeof(ctypes.c_void_p) == ctypes.sizeof(ctypes.c_int64):
-            time_t = ctypes.c_int64
-        else:
-            time_t = ctypes.c_int32
-        an_engine.set_timer_callback(
-            solver,
-            ctypes.cast(
-                ctypes.CFUNCTYPE(time_t)(callback),
-                ctypes.c_voidp).value)
-    else:
-        an_engine.set_timer_callback(solver, 0)
-
-    # Set field star position array
-    n = len(xy)
-    xy = numpy.asanyarray(xy)
-    field = an_engine.starxy_new(n, flux is not None, False)
-    if flux is not None:
-        flux = numpy.asanyarray(flux)
-        if len(flux) != n:
-            raise ValueError(
-                'Flux array must be of the same length as XY array')
-        if max_sources:
-            order = numpy.argsort(flux)[::-1]
-            xy, flux = xy[order], flux[order]
-            del order
-        an_engine.starxy_set_flux_array(field, flux)
-    an_engine.starxy_set_xy_array(field, xy.ravel())
-    an_engine.solver_set_field(solver, field)
-
-    try:
-        # Initialize solver parameters
-        if width:
-            minx, maxx = 1, int(width)
-        else:
-            minx, maxx = xy[:, 0].min(), xy[:, 0].max()
-        if height:
-            miny, maxy = 1, int(height)
-        else:
-            miny, maxy = xy[:, 1].min(), xy[:, 1].max()
-        an_engine.solver_set_field_bounds(solver, minx, maxx, miny, maxy)
-        solver.quadsize_min = 0.1*min(maxx - minx + 1, maxy - miny + 1)
-
-        if crpix_center != '':
-            solver.set_crpix = solver.set_crpix_center = int(crpix_center)
-
-        an_engine.solver_set_radec(solver, ra, dec, r)
-
-        solver.funits_lower = float(min_scale)
-        solver.funits_upper = float(max_scale)
-
-        solver.logratio_tokeep = numpy.log(1e12)
-        solver.distance_from_quad_bonus = True
-
-        if parity is None or parity == '':
-            solver.parity = an_engine.PARITY_BOTH
-        elif int(parity):
-            solver.parity = an_engine.PARITY_NORMAL
-        else:
-            solver.parity = an_engine.PARITY_FLIP
-
-        enable_sip = sip_order and int(sip_order) >= 2
-        if enable_sip:
-            solver.do_tweak = True
-            solver.tweak_aborder = int(sip_order)
-            solver.tweak_abporder = int(sip_order) + 1
-        else:
-            solver.do_tweak = False
-
-        if max_sources:
-            solver.endobj = max_sources
-        else:
-            solver.endobj = 0
-
-        # Find indexes needed to solve the field
-        fmin = solver.quadsize_min*min_scale
-        fmax = numpy.hypot(width, height)*max_scale
-        indices = []
-        for index in engine.indexes:
-            if fmin > index.index_scale_upper or \
-                    fmax < index.index_scale_lower:
-                continue
-            if not an_engine.index_is_within_range(index, ra, dec, r):
-                continue
-
-            indices.append(index)
-
-        if not len(indices):
-            raise ValueError(
-                'No indexes found for the given scale and position')
-
-        # Sort indices by scale (larger scales/smaller indices first - should
-        # be faster) then by distance from expected position
-        indices.sort(
-            key=lambda _idx: (
-                -_idx.index_scale_upper,
-                an_engine.healpix_distance_to_radec(
-                    _idx.healpix, _idx.hpnside, ra, dec)[0]
-                if _idx.healpix >= 0 else 0,
-            ))
-        an_engine.solver_clear_indexes(solver)
-        for index in indices:
-            an_engine.solver_add_index(solver, index)
-
-        # Run the solver
-        an_engine.solver_run(solver)
-        sol = Solution()
-
-        if solver.have_best_match:
-            best_match = solver.best_match
-            sol.log_odds = solver.best_logodds
-            sol.n_match = best_match.nmatch
-            sol.n_conflict = best_match.nconflict
-            sol.n_field = best_match.nfield
-            if best_match.index is not None:
-                sol.index_name = best_match.index.indexname
-        else:
-            best_match = None
-
-        if solver.best_match_solves:
-            # Get WCS parameters of best solution
-            sol.wcs = WCS(naxis=2)
-
-            wcs_ctype = ('RA---TAN', 'DEC--TAN')
-            if enable_sip:
-                sip = best_match.sip
-                try:
-                    wcstan = sip.wcstan
-                except AttributeError:
-                    # Unable to compute SIP distortions, too few sources?
-                    wcstan = best_match.wcstan
-                else:
-                    a_order, b_order = sip.a_order, sip.b_order
-                    if a_order > 0 or b_order > 0:
-                        ap_order, bp_order = sip.ap_order, sip.bp_order
-                        maxorder = an_engine.SIP_MAXORDER
-                        a = array_from_swig(
-                            sip.a, (maxorder, maxorder)
-                        )[:a_order + 1, :a_order + 1]
-                        b = array_from_swig(
-                            sip.b, (maxorder, maxorder)
-                        )[:b_order + 1, :b_order + 1]
-                        if a.any() or b.any():
-                            ap = array_from_swig(
-                                sip.ap, (maxorder, maxorder)
-                            )[:ap_order + 1, :ap_order + 1]
-                            bp = array_from_swig(
-                                sip.bp, (maxorder, maxorder)
-                            )[:bp_order + 1, :bp_order + 1]
-                            sol.wcs.sip = Sip(
-                                a, b, ap, bp,
-                                array_from_swig(wcstan.crpix, (2,)))
-                            wcs_ctype = ('RA---TAN-SIP', 'DEC--TAN-SIP')
-            else:
-                wcstan = best_match.wcstan
-            sol.wcs.wcs.ctype = wcs_ctype
-            sol.wcs.wcs.crpix = array_from_swig(wcstan.crpix, (2,))
-            sol.wcs.wcs.crval = array_from_swig(wcstan.crval, (2,))
-            sol.wcs.wcs.cd = array_from_swig(wcstan.cd, (2, 2))
-        elif retry_lost and (radius < 180 or parity is not None):
-            # When no solution was found, retry with all constraints relaxed
-            an_engine.solver_cleanup_field(solver)
-            return solve_field(
-                engine, xy, flux, width, height, 0, 0, 180, min_scale,
-                max_scale, None, sip_order, crpix_center, max_sources,
-                retry_lost=False)
-
-        return sol
-    finally:
-        # Cleanup and make solver ready for the next solution
-        an_engine.solver_cleanup_field(solver)
-        an_engine.solver_clear_indexes(solver)
+    solver_backend = get_backend(backend)
+    return solver_backend.solve(request, engine=engine)
 
 
-def solve_field_glob(engine, xy, flux=None, width=None, height=None,
-                     ra_hours=0, dec_degs=0, radius=180, min_scale=0.1,
-                     max_scale=10, parity=None, sip_order=3, crpix_center=True,
-                     max_sources=None, retry_lost=True, callback=None,
-                     min_sources=10, initial_radius=1, radius_step=0.8) \
-        -> Solution:
+def solve_field_glob(
+    engine,
+    request: SolveRequest,
+    min_sources: int = 10,
+    initial_radius: float = 1,
+    radius_step: float = 0.8,
+) -> Solution:
     """
     Obtain astrometric solution given XY coordinates of field stars; works
-    for fields around globular clusters
-
-    :param :class:`Solver` engine: Astrometry.net engine solver instance
-    :param array_like xy: (n x 2) array of 1-based X and Y pixel coordinates
-        of stars
-    :param array_like flux: optional n-element array of star fluxes
-    :param int width: image width in pixels; defaults to the maximum minus
-        minimum X coordinate of stars
-    :param int height: image height in pixels; defaults to the maximum minus
-        minimum Y coordinate of stars
-    :param float ra_hours: optional RA of image center in hours; default: 0
-    :param float dec_degs: optional Dec of image center in degrees; default: 0
-    :param float radius: optional field search radius in degrees; default: 180
-        (search over the whole sky)
-    :param float min_scale: optional minimum pixel scale in arcseconds per
-        pixel; default: 0.1
-    :param float max_scale: optional maximum pixel scale in arcseconds per
-        pixel; default: 10
-    :param bool | None parity: image parity (sign of coordinate transformation
-        matrix determinant): True = normal parity, False = flipped image, None
-        (default) = try both
-    :param int sip_order: order of SIP distortion terms; default: 3;
-        0 - disable calculation of distortion
-    :param bool crpix_center: set reference pixel to image center
-    :param int max_sources: use only the given number of brightest sources;
-        0/""/None (default) = no limit
-    :param bool retry_lost: if solution failed, retry in the "lost in space"
-        mode, i.e. without coordinate restrictions (`radius` = 180) and with
-        opposite parity, unless the initial search already had these
-        restrictions disabled
-    :param callable callback: optional callable that is regularly called
-        by the solver, accepts no arguments, and returns 0 to interrupt
-        the solution and 1 otherwise
-    :param int min_sources: minimum number of sources outside the cluster
-        exclusion circle required to find a solution
-    :param float initial_radius: initial exclusion circle radius in units
-        of the globular cluster radius
-    :param float radius_step: gradually decrease the exclusion circle radius
-        by this factor if not enough sources outside the circle
-
-    :return: astrometric solution object; its `wcs` attribute is set to None if
-        solution was not found
+    for fields around globular clusters.
     """
-    sol = solve_field(
-        engine,
-        xy,
-        flux=flux,
-        width=width,
-        height=height,
-        ra_hours=ra_hours,
-        dec_degs=dec_degs,
-        radius=radius,
-        min_scale=min_scale,
-        max_scale=max_scale,
-        parity=parity,
-        sip_order=sip_order,
-        crpix_center=crpix_center,
-        max_sources=max_sources,
-        retry_lost=retry_lost,
-        callback=callback,
-    )
-    if sol.wcs is not None and len(xy) >= min_sources:
-        n = len(xy)
-        xy = numpy.asarray(xy)
-        flux = numpy.asarray(flux)
+
+    if request.xy is None:
+        raise ValueError("xy must be provided for solve_field_glob")
+
+    sol = solve_field(request, backend="an", engine=engine)
+    if sol.wcs is not None and len(request.xy) >= min_sources:
+        n = len(request.xy)
+        xy = numpy.asarray(request.xy)
+        flux = numpy.asarray(request.flux)
         ra, dec = sol.wcs.all_pix2world(xy[:, 0], xy[:, 1], 1)
         ra %= 360
         ra /= 15
-        radius = (dec.max() - dec.min())/2
+        radius = (dec.max() - dec.min()) / 2
         for ra0, dec0, r0 in engine.globs:
-            r = r0*initial_radius
+            r = r0 * initial_radius
             found = False
             prev_num_outer = None
             while True:
@@ -473,11 +84,25 @@ def solve_field_glob(engine, xy, flux=None, width=None, height=None,
                 if num_outer >= min_sources and num_outer != prev_num_outer:
                     # Repeat solution keeping only sources outside the glob
                     prev_num_outer = num_outer
-                    new_sol = solve_field(
-                        engine, xy[outer], flux[outer], width, height,
-                        sol.wcs.wcs.crval[0]/15, sol.wcs.wcs.crval[1], radius,
-                        min_scale, max_scale, parity, 0, crpix_center,
-                        max_sources, False, callback)
+                    new_request = SolveRequest(
+                        xy=xy[outer],
+                        flux=flux[outer] if request.flux is not None else None,
+                        width=request.width,
+                        height=request.height,
+                        ra_hours=sol.wcs.wcs.crval[0] / 15,
+                        dec_degs=sol.wcs.wcs.crval[1],
+                        radius=radius,
+                        min_scale=request.min_scale,
+                        max_scale=request.max_scale,
+                        parity=request.parity,
+                        sip_order=0,
+                        crpix_center=request.crpix_center,
+                        max_sources=request.max_sources,
+                        retry_lost=False,
+                        callback=request.callback,
+                        backend_config=request.backend_config,
+                    )
+                    new_sol = solve_field(new_request, backend="an", engine=engine)
                     if new_sol.wcs is not None:
                         # New solution found with outer sources only
                         sol = new_sol

--- a/skylib/astrometry/request.py
+++ b/skylib/astrometry/request.py
@@ -1,0 +1,38 @@
+"""Backend-agnostic solver request definition."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import numpy
+
+from .configs import BackendConfig
+
+__all__ = ["SolveRequest"]
+
+
+@dataclass
+class SolveRequest:
+    """Backend-agnostic request for astrometric solving."""
+
+    image_path: Optional[Path] = None
+    xy: Optional[numpy.ndarray] = None
+    flux: Optional[numpy.ndarray] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    ra_hours: float = 0.0
+    dec_degs: float = 0.0
+    radius: float = 180.0
+    min_scale: float = 0.1
+    max_scale: float = 10.0
+    fov: Optional[float] = None
+    parity: Optional[bool] = None
+    sip_order: int = 3
+    crpix_center: bool = True
+    max_sources: Optional[int] = None
+    retry_lost: bool = True
+    callback: Optional[callable] = None
+    downsample: Optional[int] = None
+    backend_config: Optional[BackendConfig] = None

--- a/skylib/astrometry/solution.py
+++ b/skylib/astrometry/solution.py
@@ -1,0 +1,34 @@
+"""Shared astrometric solution container."""
+
+from __future__ import annotations
+
+from astropy.wcs import WCS
+
+__all__ = ["Solution"]
+
+
+class Solution(object):
+    """
+    Class that encapsulates the results of astrometric reduction, including WCS
+    and some solution statistics.
+
+    Attributes::
+        wcs: :class:`astropy.wcs.WCS` containing the World Coordinate System
+            info for solution; None if solution was not found
+        log_odds: logodds of best match
+        n_match: number of matched sources
+        n_conflict: number of conflicts
+        n_field: total number of sources
+        index_name: index file name that solved the image
+        backend: backend name that produced the solution
+        backend_metadata: backend-specific metadata
+    """
+
+    wcs: WCS | None = None  # type: WCS
+    log_odds: float | None = None
+    n_match: int | None = None
+    n_conflict: int | None = None
+    n_field: int | None = None
+    index_name: str | None = None
+    backend: str | None = None
+    backend_metadata: dict | None = None


### PR DESCRIPTION
### Motivation

- Replace the free-form backend config dict with strongly-typed configuration objects to improve discoverability and runtime validation. 
- Provide per-backend default values and clear error messages when an incorrect config type is supplied. 
- Plumb typed configs through the existing backend registry and solver API so callers can pass structured config objects.

### Description

- Add `skylib/astrometry/configs.py` defining `BackendConfig`, `AstapConfig`, and `PlateSolveConfig` dataclasses and use them as the typed config representations. 
- Change `SolveRequest.backend_config` type to `Optional[BackendConfig]` in `skylib/astrometry/request.py` so requests carry typed backend configuration. 
- Update ASTAP and PlateSolve backends to accept defaults when `backend_config` is `None`, validate `isinstance(..., AstapConfig|PlateSolveConfig)` and raise `TypeError` for incorrect types, and read config fields (`cmd`, `catalog`, `downsample`, `cmdline`, `wcs_path`) instead of mapping lookups. 
- Ensure `solve_field`/`solve_field_glob` delegate to the backend registry (`get_backend`/`available_backends`) and pass the `SolveRequest` through to backends unchanged.

### Testing

- No automated tests were executed for this change.
- Changes were committed locally without running a CI or unit test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695938d0e2a883309b25c27a4e0141f1)