### PR TITLE
Include atlas packages in Meson install

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,9 @@ if windows
     add_project_arguments(['-include', extra + 'an-defs.h', '-D_POSIX', '-D_POSIX_C_SOURCE'], language: 'c')
 endif
 
-foreach p: ['skylib', 'skylib/astrometry', 'skylib/calibration', 'skylib/color', 'skylib/combine',
+foreach p: ['skylib', 'skylib/astrometry', 'skylib/astrometry/atlas', 'skylib/astrometry/atlas/catalog',
+            'skylib/astrometry/atlas/extract', 'skylib/astrometry/atlas/match', 'skylib/astrometry/atlas/solve',
+            'skylib/astrometry/atlas/wcs', 'skylib/calibration', 'skylib/color', 'skylib/combine',
             'skylib/enhancement', 'skylib/ephem', 'skylib/extraction', 'skylib/io', 'skylib/photometry',
             'skylib/sonification', 'skylib/util']
     sources = run_command(


### PR DESCRIPTION
### Motivation
- Ensure the `skylib/astrometry/atlas` package and its subpackages are included in the Python install step so they are packaged and available at runtime.
- The previous `py.install_sources` loop did not enumerate the atlas subdirectories, causing those modules to be omitted from installs.

### Description
- Updated `meson.build` to extend the `foreach` list used for `py.install_sources` to include `skylib/astrometry/atlas` and its subdirectories `catalog`, `extract`, `match`, `solve`, and `wcs`.
- The change adds the atlas paths to the same `py.install_sources` mechanism used for other `skylib` packages so files are installed under the correct `subdir`.

### Testing
- No automated tests or CI jobs were run as part of this change.
- Local commit and file update completed successfully for `meson.build`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be43371d88330b6d29cd1a64e1af0)