### PR TITLE
Add UCAC4 zone size validation

### DIFF
--- a/skylib/astrometry/atlas/catalog/ucac4.py
+++ b/skylib/astrometry/atlas/catalog/ucac4.py
@@ -47,6 +47,15 @@ class Ucac4Index:
         if not path.exists():
             return None
 
+        file_size = path.stat().st_size
+        if file_size % _RECORD_SIZE != 0:
+            raise ValueError(
+                "UCAC4 zone file size is not a multiple of the record size "
+                f"({_RECORD_SIZE} bytes): {path} ({file_size} bytes). "
+                "This typically indicates the wrong catalog directory or a "
+                "corrupted zone file."
+            )
+
         mm = np.memmap(path, dtype=_UCAC4_DTYPE, mode="r")
         if mm.size == 0:
             return None


### PR DESCRIPTION
### Motivation
- Prevent attempting to memory-map malformed UCAC4 zone files which can lead to confusing errors at runtime.
- Surface a clear, actionable error when a zone file size is not a multiple of the expected record size.

### Description
- Add a file-size check in `Ucac4Index._load_zone` using `path.stat().st_size` and the `_RECORD_SIZE` constant.
- Raise a `ValueError` with a descriptive message explaining the record-size mismatch and likely causes (wrong catalog directory or corrupted file) when the size check fails.
- Perform the size validation before calling `np.memmap(path, ...)` to fail fast and with a clear error.

### Testing
- No automated tests were executed as part of this change.
- The change is limited to a runtime precondition check and does not alter existing parsing logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be5b646548330aaabedc28ab82979)