### PR TITLE
Refactor Atlas catalog selection and add UCAC5 support

### DIFF
--- a/skylib/astrometry/atlas/catalog/__init__.py
+++ b/skylib/astrometry/atlas/catalog/__init__.py
@@ -1,0 +1,42 @@
+"""Atlas catalog registry for plate solving."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Protocol
+
+from .ucac4 import Ucac4Index
+from .ucac5 import Ucac5Index
+
+
+@dataclass(frozen=True)
+class CatalogSpec:
+    name: str
+    index_factory: Callable[[Path], "CatalogIndex"]
+
+
+class CatalogIndex(Protocol):
+    def query_box(
+        self,
+        ra_min_deg: float,
+        ra_max_deg: float,
+        dec_min_deg: float,
+        dec_max_deg: float,
+        *,
+        thin: int = 1,
+    ):
+        ...
+
+
+CATALOG_REGISTRY: Mapping[str, CatalogSpec] = {
+    "ucac4": CatalogSpec(name="ucac4", index_factory=Ucac4Index),
+    "ucac5": CatalogSpec(name="ucac5", index_factory=Ucac5Index),
+}
+
+
+def get_catalog_spec(name: str) -> CatalogSpec:
+    normalized = name.strip().lower()
+    if normalized not in CATALOG_REGISTRY:
+        raise ValueError(f"Unsupported catalog: {name}")
+    return CATALOG_REGISTRY[normalized]

--- a/skylib/astrometry/atlas/catalog/ucac5.py
+++ b/skylib/astrometry/atlas/catalog/ucac5.py
@@ -1,0 +1,131 @@
+"""UCAC5 catalog access using local zone files."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import numpy as np
+
+_UCAC5_DTYPE = np.dtype(
+    [
+        ("pad", "u1", 4),
+        ("ra", "<u4"),
+        ("dec", "<i4"),
+        ("rest", "u1", 68),
+    ]
+)
+_RECORD_SIZE = _UCAC5_DTYPE.itemsize
+_MAS_TO_DEG = 1.0 / (1000.0 * 3600.0)
+
+
+@dataclass
+class Ucac5QueryResult:
+    ra_deg: np.ndarray
+    dec_deg: np.ndarray
+
+
+class Ucac5Index:
+    """Memory-mapped UCAC5 zone reader with RA-sorted queries."""
+
+    def __init__(self, root: Path, cache_size: int = 4) -> None:
+        self.root = Path(root)
+        self.cache_size = max(1, int(cache_size))
+        self._cache: "OrderedDict[int, np.memmap]" = OrderedDict()
+
+    def _zone_path(self, zone: int) -> Path:
+        return self.root / f"Z{zone:03d}.UC5"
+
+    def _load_zone(self, zone: int) -> np.memmap | None:
+        if zone in self._cache:
+            self._cache.move_to_end(zone)
+            return self._cache[zone]
+
+        path = self._zone_path(zone)
+        if not path.exists():
+            return None
+
+        file_size = path.stat().st_size
+        if file_size % _RECORD_SIZE != 0:
+            raise ValueError(
+                "UCAC5 zone file size is not a multiple of the record size "
+                f"({_RECORD_SIZE} bytes): {path} ({file_size} bytes). "
+                "This typically indicates the wrong catalog directory or a "
+                "corrupted zone file."
+            )
+
+        mm = np.memmap(path, dtype=_UCAC5_DTYPE, mode="r")
+        if mm.size == 0:
+            return None
+
+        self._cache[zone] = mm
+        if len(self._cache) > self.cache_size:
+            self._cache.popitem(last=False)
+        return mm
+
+    def query_box(
+        self,
+        ra_min_deg: float,
+        ra_max_deg: float,
+        dec_min_deg: float,
+        dec_max_deg: float,
+        *,
+        thin: int = 1,
+    ) -> Ucac5QueryResult:
+        """Query catalog stars inside a RA/Dec rectangle in degrees."""
+
+        thin = max(1, int(thin))
+        ra_min_deg %= 360.0
+        ra_max_deg %= 360.0
+        dec_min_deg = max(-90.0, dec_min_deg)
+        dec_max_deg = min(90.0, dec_max_deg)
+
+        zones = _zones_for_dec_range(dec_min_deg, dec_max_deg)
+        intervals = _ra_intervals(ra_min_deg, ra_max_deg)
+
+        ra_out: list[np.ndarray] = []
+        dec_out: list[np.ndarray] = []
+        dec_min_mas = dec_min_deg / _MAS_TO_DEG
+        dec_max_mas = dec_max_deg / _MAS_TO_DEG
+
+        for zone in zones:
+            mm = self._load_zone(zone)
+            if mm is None:
+                continue
+            ra_mas = mm["ra"]
+            dec_mas = mm["dec"]
+            for ra_start_deg, ra_end_deg in intervals:
+                ra_start_mas = ra_start_deg / _MAS_TO_DEG
+                ra_end_mas = ra_end_deg / _MAS_TO_DEG
+                lo = np.searchsorted(ra_mas, ra_start_mas, side="left")
+                hi = np.searchsorted(ra_mas, ra_end_mas, side="right")
+                if hi <= lo:
+                    continue
+                ra_slice = ra_mas[lo:hi:thin]
+                dec_slice = dec_mas[lo:hi:thin]
+                mask = (dec_slice >= dec_min_mas) & (dec_slice <= dec_max_mas)
+                if not np.any(mask):
+                    continue
+                ra_out.append(ra_slice[mask].astype(np.float64) * _MAS_TO_DEG)
+                dec_out.append(dec_slice[mask].astype(np.float64) * _MAS_TO_DEG)
+
+        if not ra_out:
+            return Ucac5QueryResult(np.empty(0), np.empty(0))
+
+        return Ucac5QueryResult(np.concatenate(ra_out), np.concatenate(dec_out))
+
+
+def _zones_for_dec_range(dec_min_deg: float, dec_max_deg: float) -> Iterable[int]:
+    zone_min = int(np.floor(dec_min_deg + 90.0))
+    zone_max = int(np.floor(dec_max_deg + 90.0))
+    zone_min = max(0, min(179, zone_min))
+    zone_max = max(0, min(179, zone_max))
+    return range(zone_min, zone_max + 1)
+
+
+def _ra_intervals(ra_min_deg: float, ra_max_deg: float) -> Tuple[Tuple[float, float], ...]:
+    if ra_min_deg <= ra_max_deg:
+        return ((ra_min_deg, ra_max_deg),)
+    return ((ra_min_deg, 360.0), (0.0, ra_max_deg))

--- a/skylib/astrometry/atlas/solve/solver.py
+++ b/skylib/astrometry/atlas/solve/solver.py
@@ -1,4 +1,4 @@
-"""Assisted plate solver using UCAC4 catalog zones."""
+"""Assisted plate solver using UCAC catalog zones."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.wcs.utils import proj_plane_pixel_scales
 
-from skylib.astrometry.atlas.catalog.ucac4 import Ucac4Index
+from skylib.astrometry.atlas.catalog import CatalogIndex, get_catalog_spec
 from skylib.astrometry.atlas.extract.sources import ExtractedSources, extract_sources
 from skylib.astrometry.atlas.match.triangles import TriangleSet, build_kdtree, sample_triangles
 from skylib.astrometry.atlas.wcs.build import wcs_from_similarity
@@ -32,8 +32,10 @@ class SolveResult:
 
 def solve(
     fits_path: Path,
-    ucac4_root: Path,
+    ucac4_root: Optional[Path] = None,
     *,
+    catalog: str = "ucac4",
+    ucac5_root: Optional[Path] = None,
     ra0_deg: float,
     dec0_deg: float,
     scale_range_arcsec_per_pix: Tuple[float, float],
@@ -76,8 +78,9 @@ def solve(
     ra_half = (ra_width / cos_dec) / 2.0
     dec_half = dec_height / 2.0
 
-    ucac4 = Ucac4Index(ucac4_root)
-    cat = ucac4.query_box(
+    catalog_name, catalog_root = _resolve_catalog(catalog, ucac4_root, ucac5_root)
+    catalog_index = _catalog_index(catalog_name, catalog_root)
+    cat = catalog_index.query_box(
         ra0_deg - ra_half,
         ra0_deg + ra_half,
         dec0_deg - dec_half,
@@ -159,6 +162,7 @@ def solve(
         "rotation_deg": float(np.rad2deg(np.arctan2(rotation[1, 0], rotation[0, 0]))),
         "rms_arcsec": float(rms * (180.0 / np.pi) * 3600.0),
         "inliers": int(inliers),
+        "catalog": catalog_name,
         "match_method": "triangles",
         "elapsed_s": float(elapsed),
     }
@@ -329,3 +333,25 @@ def _refine_center(
     matched_cat = cat_xy[idx[mask]]
     scale, rotation, translation = _fit_similarity(matched_obs, matched_cat)
     return wcs_from_similarity(scale, rotation, translation, ra0_deg, dec0_deg)
+
+
+def _resolve_catalog(
+    catalog: str,
+    ucac4_root: Optional[Path],
+    ucac5_root: Optional[Path],
+) -> Tuple[str, Path]:
+    catalog_name = catalog.strip().lower()
+    if catalog_name == "ucac4":
+        if ucac4_root is None:
+            raise ValueError("ucac4_root must be provided for UCAC4 catalog")
+        return catalog_name, ucac4_root
+    if catalog_name == "ucac5":
+        if ucac5_root is None:
+            raise ValueError("ucac5_root must be provided for UCAC5 catalog")
+        return catalog_name, ucac5_root
+    raise ValueError(f"Unsupported catalog: {catalog}")
+
+
+def _catalog_index(catalog: str, root: Path) -> CatalogIndex:
+    spec = get_catalog_spec(catalog)
+    return spec.index_factory(root)

--- a/skylib/astrometry/main.py
+++ b/skylib/astrometry/main.py
@@ -104,7 +104,10 @@ class PlateSolveConfig:
 
 @dataclass
 class AtlasConfig:
-    ucac4_root: Path
+    ucac4_root: Optional[Path] = None
+    ucac5_root: Optional[Path] = None
+    catalog: str = "ucac4"
+    catalog_roots: Mapping[str, Path] = field(default_factory=dict)
     timeout_s: Optional[float] = None
     max_catalog_stars: int = 400
     max_image_stars: int = 120
@@ -114,6 +117,20 @@ class AtlasConfig:
     match_tol_arcsec: float = 6.0
     refine_center: bool = True
     thin: int = 1
+
+    def resolve_catalog(self) -> tuple[str, Path]:
+        catalog = self.catalog.strip().lower()
+        if catalog in self.catalog_roots:
+            return catalog, self.catalog_roots[catalog]
+        if catalog == "ucac4":
+            if self.ucac4_root is None:
+                raise ValueError("ucac4_root must be provided for UCAC4 catalog")
+            return catalog, self.ucac4_root
+        if catalog == "ucac5":
+            if self.ucac5_root is None:
+                raise ValueError("ucac5_root must be provided for UCAC5 catalog")
+            return catalog, self.ucac5_root
+        raise ValueError(f"Unsupported catalog: {self.catalog}")
 
 
 class AstrometryNetSolver:
@@ -500,7 +517,9 @@ class AtlasBackend:
         if not isinstance(config, AtlasConfig):
             raise ValueError("Atlas config is required")
         if request.image_path is None:
-            raise ValueError("image_path must be provided for UCAC4 backend")
+            raise ValueError("image_path must be provided for Atlas backend")
+
+        catalog, catalog_root = config.resolve_catalog()
 
 
         fov_guess = None
@@ -509,7 +528,8 @@ class AtlasBackend:
 
         result = atlas_solve(
             request.image_path,
-            config.ucac4_root,
+            catalog_root,
+            catalog=catalog,
             ra0_deg=float(request.ra_hours) * 15.0,
             dec0_deg=float(request.dec_degs),
             scale_range_arcsec_per_pix=(float(request.min_scale), float(request.max_scale)),
@@ -727,6 +747,9 @@ def solve_field(
     image_path: Path = None,
     downsample: Optional[int] = None,
     ucac4_root: Optional[Path] = None,
+    ucac5_root: Optional[Path] = None,
+    atlas_catalog: str = "ucac4",
+    atlas_catalog_roots: Optional[Mapping[str, Path]] = None,
 ) -> SolveSolution:
     """Obtain astrometric solution given XY coordinates of field stars."""
 
@@ -764,9 +787,12 @@ def solve_field(
     elif backend == "astap":
         configs["astap"] = AstapConfig(cmd=astap_cmd, catalog=astap_catalog)
     elif backend == "atlas":
-        if ucac4_root is None:
-            raise ValueError("ucac4_root must be provided for Atlas backend")
-        configs["atlas"] = AtlasConfig(ucac4_root=ucac4_root)
+        configs["atlas"] = AtlasConfig(
+            ucac4_root=ucac4_root,
+            ucac5_root=ucac5_root,
+            catalog=atlas_catalog,
+            catalog_roots=atlas_catalog_roots or {},
+        )
 
     return solve_field_v2(request, backend=backend, configs=configs)
 


### PR DESCRIPTION
### Motivation
- Make it straightforward to add new catalogs (e.g., APASS) by centralizing catalog selection and index creation behind a registry and protocol. 
- Provide UCAC5 zone-file support so the Atlas solver can use either UCAC4 or UCAC5 catalogs. 
- Allow supplying multiple catalog roots via a shared mapping to avoid proliferating dedicated root fields. 
- Surface which catalog was used in solver metadata for diagnostics and reproducibility.

### Description
- Add a catalog registry and `CatalogIndex` protocol in `skylib/astrometry/atlas/catalog/__init__.py` and register `ucac4` and `ucac5` via `CatalogSpec` and `get_catalog_spec`.
- Implement `Ucac5Index` and `Ucac5QueryResult` in `skylib/astrometry/atlas/catalog/ucac5.py` for memory-mapped zone access and RA-sorted `query_box` queries.
- Refactor the Atlas solver to resolve the catalog with `_resolve_catalog` and instantiate indexes via `_catalog_index` that uses the registry, and include the chosen `catalog` in returned metadata.
- Extend `AtlasConfig` and `solve_field` to support optional `ucac5_root`, a `catalog` name, and a `catalog_roots` mapping, and wire `AtlasBackend` to use `config.resolve_catalog()`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c02007fa08330bd0b2d086f037786)