### PR TITLE
Move AtlasConfig into atlas module; accept config in solver; add UCAC5 query + memmap cache

### DIFF
--- a/skylib/astrometry/atlas/__init__.py
+++ b/skylib/astrometry/atlas/__init__.py
@@ -1,0 +1,3 @@
+from .config import AtlasConfig
+
+__all__ = ["AtlasConfig"]

--- a/skylib/astrometry/atlas/catalog/ucac5.py
+++ b/skylib/astrometry/atlas/catalog/ucac5.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Tuple
@@ -14,6 +15,7 @@ _UCAC5_BINS_PER_ZONE = 1440
 
 _UCAC5_ZONE_HEIGHT_DEG = 180.0 / _UCAC5_ZONES        # 0.2 deg
 _UCAC5_BIN_WIDTH_DEG = 360.0 / _UCAC5_BINS_PER_ZONE  # 0.25 deg
+_MAS_TO_DEG = 1.0 / (1000.0 * 3600.0)
 
 
 @dataclass(frozen=True)
@@ -22,6 +24,12 @@ class Ucac5Span:
     zone: int          # 1..900
     start: int         # 0-based record start index within zone file
     count: int         # number of records
+
+
+@dataclass
+class Ucac5QueryResult:
+    ra_deg: np.ndarray
+    dec_deg: np.ndarray
 
 
 class Ucac5Index:
@@ -38,9 +46,12 @@ class Ucac5Index:
           z900
     """
 
-    def __init__(self, root: str | Path, *, u5z_subdir: str = "u5z"):
+    def __init__(self, root: str | Path, *, u5z_subdir: str = "u5z", cache_size: int = 4):
         self.root = Path(root)
         self.u5z_dir = self.root / u5z_subdir
+        self.cache_size = max(1, int(cache_size))
+        self._cache: "OrderedDict[int, np.memmap]" = OrderedDict()
+        self._record_size: int | None = None
 
         if not self.u5z_dir.exists():
             raise FileNotFoundError(f"Missing UCAC5 u5z directory: {self.u5z_dir}")
@@ -59,11 +70,65 @@ class Ucac5Index:
 
         # [zone-1, bin-1, (start,count)]
         self._idx = raw.reshape((_UCAC5_ZONES, _UCAC5_BINS_PER_ZONE, 2))
+        starts = self._idx[:, :, 0]
+        counts = self._idx[:, :, 1]
+        self._zone_record_counts = np.max(starts + counts, axis=1).astype(int)
 
     def zone_path(self, zone: int) -> Path:
         if not (1 <= zone <= _UCAC5_ZONES):
             raise ValueError(f"zone out of range: {zone}")
         return self.u5z_dir / f"z{zone:03d}"
+
+    def _load_zone(self, zone: int) -> np.memmap | None:
+        if zone in self._cache:
+            self._cache.move_to_end(zone)
+            return self._cache[zone]
+
+        record_count = int(self._zone_record_counts[zone - 1])
+        if record_count <= 0:
+            return None
+
+        path = self.zone_path(zone)
+        if not path.exists():
+            return None
+
+        file_size = path.stat().st_size
+        if file_size <= 0 or file_size % record_count != 0:
+            raise ValueError(
+                "UCAC5 zone file size is not a multiple of the record size "
+                f"({record_count} records expected): {path} ({file_size} bytes)."
+            )
+
+        record_size = file_size // record_count
+        if record_size < 8:
+            raise ValueError(
+                "UCAC5 zone file record size is smaller than RA/Dec fields: "
+                f"{path} ({record_size} bytes)."
+            )
+
+        if self._record_size is None:
+            self._record_size = record_size
+        elif self._record_size != record_size:
+            raise ValueError(
+                "UCAC5 zone files have inconsistent record sizes: "
+                f"expected {self._record_size} bytes, got {record_size} bytes in {path}."
+            )
+
+        dtype = np.dtype(
+            [
+                ("ra", "<i4"),
+                ("dec", "<i4"),
+                ("rest", "u1", record_size - 8),
+            ]
+        )
+        mm = np.memmap(path, dtype=dtype, mode="r")
+        if mm.size == 0:
+            return None
+
+        self._cache[zone] = mm
+        if len(self._cache) > self.cache_size:
+            self._cache.popitem(last=False)
+        return mm
 
     @staticmethod
     def _wrap_ra_deg(ra_deg: float) -> float:
@@ -157,3 +222,61 @@ class Ucac5Index:
                 merged.append(s)
 
         return merged
+
+    def query_box(
+        self,
+        ra_min_deg: float,
+        ra_max_deg: float,
+        dec_min_deg: float,
+        dec_max_deg: float,
+        *,
+        thin: int = 1,
+    ) -> Ucac5QueryResult:
+        """Query catalog stars inside a RA/Dec rectangle in degrees."""
+
+        thin = max(1, int(thin))
+        dec_min_deg = max(-90.0, min(dec_min_deg, dec_max_deg))
+        dec_max_deg = min(90.0, max(dec_min_deg, dec_max_deg))
+
+        a0 = self._wrap_ra_deg(ra_min_deg)
+        b0 = self._wrap_ra_deg(ra_max_deg)
+        if a0 <= b0 and abs(ra_max_deg - ra_min_deg) < 360.0:
+            ra_intervals = [(a0, b0)]
+        else:
+            ra_intervals = [(a0, 360.0), (0.0, b0)]
+
+        spans = self.spans_for_radec_box(ra_min_deg, ra_max_deg, dec_min_deg, dec_max_deg)
+        if not spans:
+            return Ucac5QueryResult(np.empty(0), np.empty(0))
+
+        ra_out: list[np.ndarray] = []
+        dec_out: list[np.ndarray] = []
+
+        for span in spans:
+            mm = self._load_zone(span.zone)
+            if mm is None:
+                continue
+            start = span.start
+            stop = start + span.count
+            if stop <= start:
+                continue
+            records = mm[start:stop:thin]
+            if records.size == 0:
+                continue
+            ra_deg = (records["ra"].astype(np.float64) * _MAS_TO_DEG) % 360.0
+            dec_deg = records["dec"].astype(np.float64) * _MAS_TO_DEG
+            mask = (dec_deg >= dec_min_deg) & (dec_deg <= dec_max_deg)
+            if ra_intervals:
+                ra_mask = np.zeros_like(mask, dtype=bool)
+                for ra_start, ra_end in ra_intervals:
+                    ra_mask |= (ra_deg >= ra_start) & (ra_deg <= ra_end)
+                mask &= ra_mask
+            if not np.any(mask):
+                continue
+            ra_out.append(ra_deg[mask])
+            dec_out.append(dec_deg[mask])
+
+        if not ra_out:
+            return Ucac5QueryResult(np.empty(0), np.empty(0))
+
+        return Ucac5QueryResult(np.concatenate(ra_out), np.concatenate(dec_out))

--- a/skylib/astrometry/atlas/config.py
+++ b/skylib/astrometry/atlas/config.py
@@ -1,0 +1,28 @@
+"""Configuration for the Atlas plate solver."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Optional
+
+
+@dataclass
+class AtlasConfig:
+    catalog: str = "ucac5"
+    catalog_roots: Mapping[str, Path] = field(default_factory=dict)
+    timeout_s: Optional[float] = None
+    max_catalog_stars: int = 400
+    max_image_stars: int = 120
+    n_tri_obs: int = 8000
+    n_tri_cat: int = 15000
+    invariant_tol: float = 0.006
+    match_tol_arcsec: float = 6.0
+    refine_center: bool = True
+    thin: int = 1
+
+    def resolve_catalog(self) -> tuple[str, Path]:
+        catalog = self.catalog.strip().lower()
+        if catalog in self.catalog_roots:
+            return catalog, self.catalog_roots[catalog]
+        raise ValueError(f"Unsupported catalog: {self.catalog}")

--- a/skylib/astrometry/atlas/solve/solver.py
+++ b/skylib/astrometry/atlas/solve/solver.py
@@ -13,6 +13,7 @@ from astropy.wcs import WCS
 from astropy.wcs.utils import proj_plane_pixel_scales
 
 from skylib.astrometry.atlas.catalog import CatalogIndex, get_catalog_spec
+from skylib.astrometry.atlas.config import AtlasConfig
 from skylib.astrometry.atlas.extract.sources import ExtractedSources, extract_sources
 from skylib.astrometry.atlas.match.triangles import TriangleSet, build_kdtree, sample_triangles
 from skylib.astrometry.atlas.wcs.build import wcs_from_similarity
@@ -32,28 +33,18 @@ class SolveResult:
 
 def solve(
     fits_path: Path,
-    catalog: str,
-    catalog_root: Path,
+    config: AtlasConfig,
     *,
     ra0_deg: float,
     dec0_deg: float,
     scale_range_arcsec_per_pix: Tuple[float, float],
     fov_guess_deg: Optional[Tuple[float, float]] = None,
-    timeout_s: Optional[float] = None,
-    max_catalog_stars: int = 400,
-    max_image_stars: int = 120,
-    n_tri_obs: int = 8000,
-    n_tri_cat: int = 15000,
-    invariant_tol: float = 0.006,
-    match_tol_arcsec: float = 6.0,
-    refine_center: bool = True,
-    thin: int = 1,
 ) -> SolveResult:
     start = time.perf_counter()
 
     sources = extract_sources(
         fits_path,
-        max_sources=max_image_stars,
+        max_sources=config.max_image_stars,
         crop_fraction=0.8,
         downsample=1,
     )
@@ -77,19 +68,25 @@ def solve(
     ra_half = (ra_width / cos_dec) / 2.0
     dec_half = dec_height / 2.0
 
-    catalog_index = _catalog_index(catalog, catalog_root)
+    catalog_name, catalog_root = config.resolve_catalog()
+    catalog_index = _catalog_index(catalog_name, catalog_root)
     cat = catalog_index.query_box(
         ra0_deg - ra_half,
         ra0_deg + ra_half,
         dec0_deg - dec_half,
         dec0_deg + dec_half,
-        thin=thin,
+        thin=config.thin,
     )
     if cat.ra_deg.size == 0:
         return SolveResult(False, None, {"reason": "empty_catalog"})
 
     cat_xy = _gnomonic_projection(cat.ra_deg, cat.dec_deg, ra0_deg, dec0_deg)
-    cat_xy, cat_radec = _limit_catalog(cat_xy, cat.ra_deg, cat.dec_deg, max_catalog_stars)
+    cat_xy, cat_radec = _limit_catalog(
+        cat_xy,
+        cat.ra_deg,
+        cat.dec_deg,
+        config.max_catalog_stars,
+    )
 
     if len(cat_xy) < 3:
         return SolveResult(False, None, {"reason": "insufficient_catalog"})
@@ -106,14 +103,14 @@ def solve(
 
     obs_tri = sample_triangles(
         obs_xy,
-        n_tri_obs,
+        config.n_tri_obs,
         min_side=min_side_pix,
         max_side=max_side_pix,
         rng=rng,
     )
     cat_tri = sample_triangles(
         cat_xy,
-        n_tri_cat,
+        config.n_tri_cat,
         min_side=min_side_rad,
         max_side=max_side_rad,
         rng=rng,
@@ -124,7 +121,7 @@ def solve(
 
     inv_tree = build_kdtree(cat_tri.invariants)
     cat_tree = cKDTree(cat_xy)
-    tol_rad = np.deg2rad(match_tol_arcsec / 3600.0)
+    tol_rad = np.deg2rad(config.match_tol_arcsec / 3600.0)
 
     best = _match_triangles(
         obs_tri,
@@ -135,9 +132,9 @@ def solve(
         a_min,
         a_max,
         tol_rad,
-        timeout_s=timeout_s,
+        timeout_s=config.timeout_s,
         start=start,
-        invariant_tol=invariant_tol,
+        invariant_tol=config.invariant_tol,
     )
     if best is None:
         return SolveResult(False, None, {"reason": "no_match"})
@@ -145,7 +142,7 @@ def solve(
     scale, rotation, translation, inliers, rms = best
     wcs = wcs_from_similarity(scale, rotation, translation, ra0_deg, dec0_deg)
 
-    if refine_center:
+    if config.refine_center:
         center_x = (width + 1) / 2.0
         center_y = (height + 1) / 2.0
         new_ra, new_dec = wcs.all_pix2world([[center_x, center_y]], 1)[0]

--- a/skylib/astrometry/main.py
+++ b/skylib/astrometry/main.py
@@ -18,6 +18,7 @@ from astropy.wcs import Sip, WCS
 
 from skylib.util.angle import angdist
 
+from .atlas import AtlasConfig
 from .atlas.solve.solver import solve as atlas_solve
 
 try:  # pragma: no cover - optional dependency
@@ -100,27 +101,6 @@ class PlateSolveConfig:
     output_suffix: str = ".txt"
     output_path: Optional[Path] = None
     cwd: Optional[Path] = None
-
-
-@dataclass
-class AtlasConfig:
-    catalog: str = "ucac5"
-    catalog_roots: Mapping[str, Path] = field(default_factory=dict)
-    timeout_s: Optional[float] = None
-    max_catalog_stars: int = 400
-    max_image_stars: int = 120
-    n_tri_obs: int = 8000
-    n_tri_cat: int = 15000
-    invariant_tol: float = 0.006
-    match_tol_arcsec: float = 6.0
-    refine_center: bool = True
-    thin: int = 1
-
-    def resolve_catalog(self) -> tuple[str, Path]:
-        catalog = self.catalog.strip().lower()
-        if catalog in self.catalog_roots:
-            return catalog, self.catalog_roots[catalog]
-        raise ValueError(f"Unsupported catalog: {self.catalog}")
 
 
 class AstrometryNetSolver:
@@ -509,30 +489,17 @@ class AtlasBackend:
         if request.image_path is None:
             raise ValueError("image_path must be provided for Atlas backend")
 
-        catalog, catalog_root = config.resolve_catalog()
-
-
         fov_guess = None
         if request.fov is not None:
             fov_guess = (float(request.fov), float(request.fov))
 
         result = atlas_solve(
             request.image_path,
-            catalog,
-            catalog_root,
+            config,
             ra0_deg=float(request.ra_hours) * 15.0,
             dec0_deg=float(request.dec_degs),
             scale_range_arcsec_per_pix=(float(request.min_scale), float(request.max_scale)),
             fov_guess_deg=fov_guess,
-            timeout_s=config.timeout_s,
-            max_catalog_stars=config.max_catalog_stars,
-            max_image_stars=config.max_image_stars,
-            n_tri_obs=config.n_tri_obs,
-            n_tri_cat=config.n_tri_cat,
-            invariant_tol=config.invariant_tol,
-            match_tol_arcsec=config.match_tol_arcsec,
-            refine_center=config.refine_center,
-            thin=config.thin,
         )
 
         sol = SolveSolution(backend=self.name)


### PR DESCRIPTION
### Motivation
- Consolidate atlas configuration into the `skylib.astrometry.atlas` package so the solver and backend share a single `AtlasConfig` object.
- Simplify the atlas solver API so it accepts a `AtlasConfig` instance instead of many positional/configuration parameters.
- Provide robust RA/Dec querying of UCAC5 zone files and reduce repeated I/O by introducing a small memmap cache.

### Description
- Added `skylib/astrometry/atlas/config.py` defining `AtlasConfig` and re-exported it from `skylib/astrometry/atlas/__init__.py` for shared use.
- Updated `skylib/astrometry/atlas/solve/solver.py` to change `solve(..., catalog, catalog_root, ...)` to `solve(..., config: AtlasConfig, ...)` and consume settings like `max_image_stars`, `thin`, `n_tri_obs`, `n_tri_cat`, `timeout_s`, `invariant_tol`, `match_tol_arcsec`, and `refine_center` from `config`.
- Modified `skylib/astrometry/main.py` `AtlasBackend` to pass the `config` through to `atlas_solve` (and import `AtlasConfig` from the atlas package), instead of expanding config fields into many arguments.
- Extended `skylib/astrometry/atlas/catalog/ucac5.py` with `_MAS_TO_DEG`, a `Ucac5QueryResult` dataclass, a `_load_zone` routine with record-size validation and a small LRU `OrderedDict` memmap cache, and a `query_box` implementation that handles RA wraparound, thinning, span merging and filtering.

### Testing
- No automated tests were run for these changes.
- Static code updates were validated by running the repository search and applying patches without runtime tests.
- Committed changes locally and verified modified files were staged and recorded in a commit.
- No unit or integration tests executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c0d3febdc8330bb3d5a93706aa690)